### PR TITLE
Correct plugin name to Eight Day Week

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Two custom roles are added by this plugin to best model a real-world print team.
 
 ## Installation
 
-Print Production has no settings or configurations to set up. It just works!
+Eight Day Week has no settings or configurations to set up. It just works!
 
 ## Filters & Hooks
 Eight Day Week provides a number of filters and hooks for customizing and extending the plugin.

--- a/assets/js/src/scripts.js
+++ b/assets/js/src/scripts.js
@@ -1,5 +1,5 @@
 /**
- * Print Production
+ * Eight Day Week
  * http://10up.com
  *
  * Copyright (c) 2015 10up, Josh Levinson, Brent Schultz

--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,7 @@ Two custom roles are added by this plugin to best model a real-world print team.
 
 == Installation ==
 
-Print Production has no settings or configurations to set up. It just works!
+Eight Day Week has no settings or configurations to set up. It just works!
 
 == Filters & Hooks ==
 Eight Day Week provides a number of filters and hooks for customizing and extending the plugin.


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

I found a couple stray "Print Production" name references, this changes those to "Eight Day Week".

### Alternate Designs

none.

### Benefits

Eliminate confusion on incorrect plugin name references.

### Possible Drawbacks

None.

### Verification Process

Manually verified via GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/eight-day-week/blob/develop/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

n/a
