### PR TITLE
Add known caveats/issues section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 * [Installation](#installation)
 * [Filters & Hooks](#filters--hooks)
 * [Screenshots](#screenshots)
+* [Known Caveats/Issues](#known-caveatsissues)
 * [Changelog](#changelog)
 * [Contributing](#contributing)
 
@@ -91,6 +92,12 @@ The information displayed in the list of Print Issues is filterable. Custom colu
 ### Article Export
 
 The export of posts in a Print Issue is highly customizeable, from the file name of the zip, to the file name of the individual files, to the contents of the files themselves.  The best reference would be to read through `includes/functions/plugins/article-export.php`.  [Here's](https://gist.github.com/joshlevinson/4a2c3ed78b21b3c54eba) a few examples used on the *Observer*.
+
+## Known Caveats/Issues
+
+### Gutenberg exports
+
+Gutenberg-based exports include some additional metadata/details that a Classic Editor-based export does not.  [Gutenberg stores block data in HTML comments](https://developer.wordpress.org/block-editor/key-concepts/#delimiters-and-parsing-expression-grammar), so you'll notice those comments (in the form of `<!-- "Gutenberg block data" -->`) appearing in the Eight Day Week XML export.  Note that the XML is still valid--you can test and confirm that yourself using an [XML validator](https://www.xmlvalidation.com/)--though depending on your version of InDesign you may get different results upon importing a Gutenberg export compared to a Classic Editor export.  Our testing showed that those HTML comments in a Gutenberg export did not affect the import into InDesign however.  You can test how this works in your version of InDesign with these sample XML files: [Gutenberg XML](https://gist.githubusercontent.com/adamsilverstein/3a9af64f4827b0ffcba963fd4b6a380a/raw/0513c4dd7cbd45b54c644a6aa9cbaaf269659b8d/classic.xml), [Classic Editor XML](https://gist.githubusercontent.com/adamsilverstein/fafae070f20232d1061c5517369a8f06/raw/b74310e18125a045cea213513fba435eee1545ff/classic2.xml).
 
 ## Support Level
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This adds a "Known Caveats/Issues" section to the README.md and includes details about differences between a Gutenberg export and a Classic Editor export.

### Alternate Designs

none

### Benefits

Ensures Eight Day Week consumers are aware of potential differences in using Gutenberg versus Classic Editor for their print production workflows.

### Possible Drawbacks

none identified

### Verification Process

Manually verified via the GitHub web UI.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/eight-day-week/blob/develop/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Relates to #43, #47.
