### PR TITLE
Fix: cant change role using upper print role dropdown

### DIFF
--- a/includes/functions/user-roles.php
+++ b/includes/functions/user-roles.php
@@ -159,14 +159,16 @@ function editable_roles( $roles ) {
 /**
  * Outputs the Print Role select on the user editor screen
  *
- * @param \WP_User $user The current user
+ * @param string $which The location of the extra table nav markup: 'top' or 'bottom'.
  */
-function output_print_role_on_user_list_table() {
+function output_print_role_on_user_list_table( $which ) {
 	global $edw_roles;
 
 	$role_names = get_role_names();
 
-	echo '<select name="pp-print-role">';
+	$select_id = 'top' === $which ? 'pp-print-role' : 'pp-print-role2';
+
+	echo '<select id="' . $select_id .'" name="' . $select_id . '">';
 	echo '<option value="-1">' . esc_html( 'Change print role to...', 'eight-day-week-print-workflow' ) . '</option>';
 	echo '<option value="remove">' . esc_html_x( 'None (remove)', 'Select option text for removing print production role.', 'eight-day-week-print-workflow' ) . '</option>';
 	foreach( (array) $edw_roles as $role ) {
@@ -230,12 +232,12 @@ function update_users_print_role() {
 
 	global $edw_roles;
 
-	if ( ! isset( $_GET['pp-print-role'] ) ) {
+	if ( ! isset( $_GET['pp-print-role'] ) || ! isset( $_GET['pp-print-role2'] ) ) {
 		return;
 	}
 
 	//don't proccess the default option
-	if( -1 == $_GET['pp-print-role'] ) {
+	if ( -1 == $_GET['pp-print-role'] && -1 == $_GET['pp-print-role2'] ) {
 		return;
 	}
 
@@ -249,7 +251,7 @@ function update_users_print_role() {
 
 	check_admin_referer( 'bulk-users' );
 
-	$new_role = $_GET['pp-print-role'];
+	$new_role = -1 != $_GET['pp-print-role'] ? $_GET['pp-print-role'] : $_GET['pp-print-role2'];
 
 	//validate requested print role
 	if ( 'remove' !== $new_role && ! in_array( $new_role, $edw_roles ) ) {


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Fixes #57 

Use different name allows user to use both upper and lower print role dropdown.

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs
N/A.
<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits
See above.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
None identified.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. Go to Users.
2. Select some users who have print role set.
3. Choose a role from the upper print role dropdown.
4. Click Change.
5. See the user's role is updated correctly.
6. Repeat the steps above but with the lower print role dropdown and see the same result.

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/eight-day-week/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
