### PR TITLE
Use DIRECTORY_SEPARATOR instead of slash in filepaths

### DIFF
--- a/eight-day-week.php
+++ b/eight-day-week.php
@@ -70,7 +70,7 @@ function edw_bootstrap() {
 		return;
 	}
 
-    $core_file = EDW_INC . 'functions' . DIRECTORY_SEPARATOR . 'core.php';
+	$core_file = EDW_INC . 'functions' . DIRECTORY_SEPARATOR . 'core.php';
 
 	if( ! isset( $map[ $core_file ] ) ) {
 		return;
@@ -139,10 +139,10 @@ function edw_build_namespace_map() {
 
 		$path = $file->getPathInfo()->getPathname();
 		if( $dir !== $path ) {
-            $sub_directory = str_replace( $dir . DIRECTORY_SEPARATOR, '', $path );
+			$sub_directory = str_replace( $dir . DIRECTORY_SEPARATOR, '', $path );
 
 			//convert slashes to spaces
-            $capitalized = ucwords( str_replace( DIRECTORY_SEPARATOR, ' ', $sub_directory ) );
+			$capitalized = ucwords( str_replace( DIRECTORY_SEPARATOR, ' ', $sub_directory ) );
 
 			$tip_of_the_iceberg = str_replace( ' ', '\\', $capitalized ) . '\\' . $tip_of_the_iceberg;
 		}

--- a/eight-day-week.php
+++ b/eight-day-week.php
@@ -70,7 +70,7 @@ function edw_bootstrap() {
 		return;
 	}
 
-	$core_file = EDW_INC . 'functions/core.php';
+    $core_file = EDW_INC . 'functions' . DIRECTORY_SEPARATOR . 'core.php';
 
 	if( ! isset( $map[ $core_file ] ) ) {
 		return;
@@ -139,10 +139,10 @@ function edw_build_namespace_map() {
 
 		$path = $file->getPathInfo()->getPathname();
 		if( $dir !== $path ) {
-			$sub_directory = str_replace( $dir . '/', '', $path );
+            $sub_directory = str_replace( $dir . DIRECTORY_SEPARATOR, '', $path );
 
 			//convert slashes to spaces
-			$capitalized = ucwords( str_replace( '/', ' ', $sub_directory ) );
+            $capitalized = ucwords( str_replace( DIRECTORY_SEPARATOR, ' ', $sub_directory ) );
 
 			$tip_of_the_iceberg = str_replace( ' ', '\\', $capitalized ) . '\\' . $tip_of_the_iceberg;
 		}


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).



-->
Use the PHP constant `[DIRECTORY_SEPARATOR](https://www.php.net/manual/en/dir.constants.php)` (which is `/` on *nix, and `\` on windows) instead of `/` in filepaths. 
Without this, the plugin doesn't work on Windows machines: EDW thinks the modules aren't defined and so doesn't try to activate them, so the "Print" admin page doesn't appear. See https://i.imgur.com/9n1CqO0.png

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->
You could alternatively do a string replace to standardize which slashes are used. This seemed simpler.

### Benefits

<!-- What benefits will be realized by the code change? -->
EDW can now work on Windows machines, including localhost installs.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

I tested this on Windows (see https://i.imgur.com/ANd5ut7.png) and on a Linux machine.
I'm able to create a print edition zip. 


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/eight-day-week/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. --> I don't think it does
- [x] I have updated the documentation accordingly. --> N/A
- [x] I have added tests to cover my change. -->I have not added tests, I don't think this is necessary
- [x] All new and existing tests passed. --> you talking crazy talk; what tests?

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
Should address #73