### PR TITLE
add observer example to readmes

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,83 @@ The information displayed in the list of Print Issues is filterable. Custom colu
 
 The export of posts in a Print Issue is highly customizable, from the file name of the zip, to the file name of the individual files, to the contents of the files themselves.  The best reference would be to read through `includes/functions/plugins/article-export.php`.  [Here's](https://github.com/10up/eight-day-week/wiki/Sample-Eight-Day-Week-filters-for-the-Observer) a few examples used on the *Observer*.
 
+**Sample Eight Day Week filters for the Observer**
+
+Examples from Observer's eight-day-week-filters.php:
+
+`
+<?php
+
+add_filter( 'Eight_Day_Week\Plugins\Article_Export\xml_outer_elements', function( $elements, $article ) {
+	$elements['subHeadline'] = get_post_meta( $article->ID, 'nyo_dek', true );
+	return $elements;
+}, 10, 2 );
+
+add_filter( 'Eight_Day_Week\Plugins\Article_Export\xml_outer_elements', function( $elements, $article ) {
+	if( function_exists( '\Eight_Day_Week\Plugins\Article_Byline\get_article_byline' ) ) {
+		$elements['byline']      = \Eight_Day_Week\Plugins\Article_Byline\get_article_byline( $article );
+	}
+	return $elements;
+}, 10, 2 );
+
+add_filter( 'Eight_Day_Week\Plugins\Article_Export\xpath_extract', function( $extract ) {
+	$extract[] = [
+		'tag_name'  => 'pullQuote',
+		'container' => 'pullQuotes',
+		'query'     => '//p[contains(@class, "pullquote")]'
+	];
+	return $extract;
+} );
+
+add_filter( 'Eight_Day_Week\Plugins\Article_Export\dom', function ( $dom ) {
+	$swap_tag_name = 'emphasized';
+
+	$extract_map = [
+		'strong' => [
+			'solo'  => 'bold',
+			'inner' => 'em'
+		],
+		'em'     => [
+			'solo'  => 'italics',
+			'inner' => 'strong'
+		],
+	];
+
+	foreach ( $extract_map as $tag_name => $map ) {
+		$nodes  = $dom->getElementsByTagName( $tag_name );
+		$length = $nodes->length;
+
+		for ( $i = $length; -- $i >= 0; ) {
+			$el         = $nodes->item( $i );
+			$emphasized = $el->getElementsByTagName( $map['inner'] );
+			if ( $emphasized->length ) {
+				$em            = $dom->createElement( $swap_tag_name );
+				$em->nodeValue = $el->nodeValue;
+				try {
+					$el->parentNode->replaceChild( $em, $el );
+				} catch ( \Exception $e ) {
+
+				}
+				continue;
+			}
+
+			$new            = $dom->createElement( $map['solo'] );
+			$new->nodeValue = $el->nodeValue;
+			try {
+				$el->parentNode->replaceChild( $new, $el );
+			} catch ( \Exception $e ) {
+
+			}
+
+		}
+
+	}
+
+	return $dom;
+
+} );
+`
+
 == Known Caveats/Issues ==
 
 **Gutenberg exports**


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This ports in the sole wiki page in this repo (https://github.com/10up/eight-day-week/wiki/Sample-Eight-Day-Week-filters-for-the-Observer) so that we can turn off the wiki and maintain all code references/examples within the readmes.

Once this PR is merged, we can remove/disable the Wiki within the repo.

### How to test the Change
Use Markdown and WP.org markdown validators to view new section renders as expected.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Filter example usages from the Observer

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
