### PR TITLE
Fix a few issues related to PHPCS changes

### DIFF
--- a/includes/functions/articles.php
+++ b/includes/functions/articles.php
@@ -522,7 +522,8 @@ function save_section_articles( $post_id ) {
 		return;
 	}
 
-	$article_ids_sets = wp_unslash( array_map( 'intval', $_POST['pi-article-ids'] ) );
+	$article_ids_sets = wp_unslash( $_POST['pi-article-ids'] );
+
 	if ( ! is_array( $article_ids_sets ) ) {
 		return;
 	}

--- a/includes/functions/plugins/article-status.php
+++ b/includes/functions/plugins/article-status.php
@@ -118,7 +118,7 @@ function admin_menu() {
  */
 function filter_article_columns_article_status( $columns ) {
 	$status = array(
-		'post_status' => __( 'Article Status', 'eight-day-week' ),
+		'article_status' => __( 'Article Status', 'eight-day-week' ),
 	);
 
 	$title_offset = array_search( 'title', array_keys( $columns ), true );
@@ -233,7 +233,7 @@ function bulk_edit_article_statuses_ajax() {
 	Core\check_elevated_ajax_referer();
 
 	$term_id     = isset( $_POST['status'] ) ? absint( $_POST['status'] ) : false;
-	$article_ids = isset( $_POST['checked_articles'] ) ? array_map( 'absint', wp_unslash( $_POST['checked_articles'] ) ) : false;
+	$article_ids = isset( $_POST['checked_articles'] ) ? wp_unslash( $_POST['checked_articles'] ) : false;
 
 	// Sanitize - only allow comma delimited integers.
 	if ( ! ctype_digit( str_replace( ',', '', $article_ids ) ) ) {

--- a/tests/cypress/support/e2e.js
+++ b/tests/cypress/support/e2e.js
@@ -19,8 +19,8 @@ import "@10up/cypress-wp-utils";
 import "./commands";
 
 // Preserve WP cookies.
-beforeEach(() => {
-  Cypress.Cookies.defaults({
-    preserve: /^wordpress.*?/,
-  });
-});
+beforeEach( () => {
+	cy.session( 'login', cy.login, {
+		cacheAcrossSpecs: true,
+	} );
+} );


### PR DESCRIPTION
### Description of the Change

In #120, a bunch of PHPCS fixes were added. While these are great, they can often have unintended consequences. As reported in #130, you can only save a single article within a section now. In looking into this, the problem is we added a sanitization method around those articles IDs when they are saved. These IDs are sent in as a comma-separated list of integers but the sanitization method used (`intval`) converts that into a single integer (thus getting rid of any articles besides the first.

I don't think we need this sanitization anyway, as we later have a check to verify that each item is an integer in this comma-separated list, so this PR removes that extra sanitization which fixes the reported issue.

In addition, I decided to look closer at the code changes in #120 and found the exact same issue in regards to bulk editing the article status of articles within a section. We added the same sanitization method and thus changing the article status only works if you have a single article selected (you'll get an error if multiple are selected).

I also noticed the information in the Article Status column wasn't reflecting the actual Article Status assigned. Looking into that, this was an issue coming out of #117, where we changed the column name from `article_status` to `post_status`. As far as I can tell there's no need for that change so I've changed that back in this PR, which fixes the bug around those showing correctly.

And finally, E2E tests aren't working since #129 was merged in, as the upgrade to Cypress 13 required some changes in our test structure. That has been fixed in this PR.

Closes #130, #125

### How to test the Change

1. Ensure you have multiple Posts added
2. Create a new Print Issue
3. Add a section to this Print Issue
4. Add multiple articles to this section and save
5. Ensure the articles persist after the save
6. Add multiple Article Statuses
7. Go back to the Print Issue, select multiple articles and change the Article Status
8. Ensure the correct status shows in the list view

### Changelog Entry

> Fixed - Ensure multiple articles can be saved within each Print Issue section
> Fixed - Ensure the article status shows correctly and can be bulk edited

### Credits

Props @dkotter, @xLesy

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
