### PR TITLE
Update readme.txt: Add comparison of Classic Editor vs. Gutenberg exports for InDesign imports

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -32,9 +32,22 @@ Two custom roles are added by this plugin to best model a real-world print team.
 
 - Circumvents the post locking feature by offering a read-only view of a print issue
 
-**XML Export to InDesign**
+**XML Export to InDesign: Classic Editor vs. Gutenberg Exports**
 
-- Export XML files specifically formatted for import into InDesign
+When exporting content from WordPress for use in InDesign, there are key differences between Classic Editor and Gutenberg (Block Editor) exports. This section highlights how each type of export behaves in InDesign and offers guidance on how to handle these differences.
+
+- Classic Editor exports use basic HTML tags like `<p>`, `<strong>`, and `<em>`, making them straightforward for import into InDesign.
+- Gutenberg exports include additional metadata such as HTML comments (`<!-- wp:paragraph -->`) that define block-level structures, which may require manual adjustments after importing into InDesign.
+
+**Import Differences:**
+
+- Classic Editor: Imports cleanly into InDesign without extra metadata.
+- Gutenberg: May include block-related metadata, requiring users to clean up the imported content or manually adjust formatting.
+
+**Recommendations:**
+
+- Classic Editor: Best for simple imports with minimal manual work.
+- Gutenberg: Recommended for users comfortable with removing metadata or adjusting block-based settings after the import.
 
 == Installation ==
 


### PR DESCRIPTION
### Description of the Change
This PR updates the readme.txt to include a new section that details the differences between Classic Editor and Gutenberg (Block Editor) exports when imported into InDesign. The goal is to help users understand how each type of export behaves during import, particularly regarding additional block metadata in Gutenberg exports and the potential need for manual adjustments when importing into design tools like InDesign.

Closes #43 (and addresses note from @dkotter [here](https://github.com/10up/eight-day-week/pull/159#issuecomment-2405411737))

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
> Added - Documentation update in the readme.txt to compare Classic Editor vs. Gutenberg (Block Editor) XML exports for InDesign imports.

### Credits
Props @frankiebordone @dkotter 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
