### PR TITLE
Update permissions to allow release asset attachment during release deploys

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -1,14 +1,18 @@
 name: Deploy to WordPress.org
+
 on:
   push:
     tags:
     - "*"
+
+permissions:
+  contents: write
+  packages: write
+    
 jobs:
   tag:
     name: New tag
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  packages: write
+  packages: read
     
 jobs:
   tag:


### PR DESCRIPTION


<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request updates the GitHub Actions workflow configuration for deploying to WordPress.org. The main change is the addition of repository-wide permissions for the workflow, which grants write access to both contents and packages.

Workflow permissions update:

* [`.github/workflows/push-deploy.yml`](diffhunk://#diff-d71c3ba30cee07edf9485b33d2e7ee90f8abcb8c853798bea3437187ebb055bbR2-L11): Added `permissions` at the top level to grant `contents: write` and `packages: write` for the workflow, replacing the previous job-specific permissions.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Fix issue with attaching release assets during release deploy action.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
