### PR TITLE
Bump tested up to header to indicate WordPress 6.9 support.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Eight Day Week Print Workflow ===
 Contributors:      10up, observerteam, joshlevinson, brs14ku, jeffpaul
 Tags:              print, workflow, editorial
-Tested up to:      6.8
+Tested up to:      6.9
 Stable tag:        1.2.6
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html


### PR DESCRIPTION
### Description of the Change

Bump tested up to header to indicate WordPress 6.9 support.

Closes #

### How to test the Change

N/A: See testing notes on the related issue.

### Changelog Entry
> Changed - Bump tested up to header to indicate WordPress 6.9 support.

### Credits
Props @peterwilsoncc 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
