### PR TITLE
Bump minimum supported WP version to 6.7

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -25,7 +25,7 @@ jobs:
           - {name: 'PHP 7.4', version: '7.4'}
         core:
           - {name: 'WP stable', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.5'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.7'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/eight-day-week.php
+++ b/eight-day-week.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/eight-day-week
  * Description:       Optimize publication workflows by using WordPress as your print CMS.
  * Version:           1.2.6
- * Requires at least: 6.5
+ * Requires at least: 6.7
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com


### PR DESCRIPTION
### Description of the Change

Increases the minimum supported version of WP from 6.5 to 6.7.

Closes #182

### How to test the Change

N/A: Docs change.

### Changelog Entry
> Changed - Minimum supported version of WordPress is now 6.7.

### Credits
Props @jeffpaul, @peterwilsoncc.

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
