### PR TITLE
Return an empty paragraph when the post content is empty and the post has no featured image

### DIFF
--- a/includes/functions/AL_Table.php
+++ b/includes/functions/AL_Table.php
@@ -9,6 +9,9 @@ namespace Eight_Day_Week\Articles;
 
 use Eight_Day_Week\User_Roles as User;
 
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
 if ( ! class_exists( '\WP_Posts_List_Table' ) ) {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
 	require_once ABSPATH . 'wp-admin/includes/class-wp-posts-list-table.php';

--- a/includes/functions/Article_XML.php
+++ b/includes/functions/Article_XML.php
@@ -122,6 +122,10 @@ class Article_XML {
 			}
 		}
 
+		if ( empty( $content ) ) {
+			return '<p></p>';
+		}
+
 		$dom = new \DOMDocument();
 		$dom->loadHTML( $content );
 

--- a/tests/cypress/e2e/admin.test.js
+++ b/tests/cypress/e2e/admin.test.js
@@ -15,6 +15,14 @@ describe('Admin can login and make sure plugin is activated', () => {
 	});
 
 	it('Can activate plugin if it is deactivated', () => {
-		cy.activatePlugin('eight-day-week');
+		cy.visit('/wp-admin/plugins.php');
+		// Depending on how the plugin is installed the slug may be either eight-day-week or eight-day-week-print-workflow.
+		cy.get(`#the-list tr[data-slug^="eight-day-week"]`).then($pluginRow => {
+				if ($pluginRow.find('.activate > a').length > 0) {
+						cy.get(`#the-list tr[data-slug^="eight-day-week"] .activate > a`)
+								.should('have.text', 'Activate')
+								.click();
+				}
+		});
 	});
 });


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Return an empty paragraph when the post content is empty and the post has no featured image

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #181

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Create a post with no content. Do not set a featured image either
2. Create a new print issue
3. Add a section
4. Add the article to the section
5. Save the print issue
6. Click the export all button
7. Observe the fatal error

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - PHP Fatal error when exporting an issue that includes a post with empty post content and a featured image.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
