### PR TITLE
Fix failing E2E tests

### DIFF
--- a/tests/cypress/e2e/admin.test.js
+++ b/tests/cypress/e2e/admin.test.js
@@ -15,6 +15,6 @@ describe('Admin can login and make sure plugin is activated', () => {
 	});
 
 	it('Can activate plugin if it is deactivated', () => {
-		cy.activatePlugin('eight-day-week-print-workflow');
+		cy.activatePlugin('eight-day-week');
 	});
 });

--- a/tests/cypress/e2e/issue-status.test.js
+++ b/tests/cypress/e2e/issue-status.test.js
@@ -16,7 +16,7 @@ describe('Issue Status', () => {
 
       it("Edit Issue Status", () => {
         cy.visit(`wp-admin/edit-tags.php?taxonomy=print_issue_status&post_type=print-issue`);
-        cy.get('[aria-label="“Active-01” (Edit)"]').click();
+        cy.get('a.row-title').contains("Active-01").first().click();
         cy.get('#name').clear();
         cy.get('#name').type('Active-02')
         cy.get('.button').click();
@@ -30,7 +30,7 @@ describe('Issue Status', () => {
 
       it("Delete Issue Status", () => {
         cy.visit(`wp-admin/edit-tags.php?taxonomy=print_issue_status&post_type=print-issue`);
-        cy.get('[aria-label="“Active-02” (Edit)"]').click();
+        cy.get('a.row-title').contains("Active-02").first().click();
         cy.get('.delete').click();
 
         // Verify successful deletion

--- a/tests/cypress/e2e/print.test.js
+++ b/tests/cypress/e2e/print.test.js
@@ -25,7 +25,7 @@ describe('Publish a new print issue', () => {
 
 	it("Add multiple section and Edit issue", () => {
 		cy.visit(`wp-admin/edit.php?post_type=print-issue`);
-		cy.get('[aria-label="“Print Title 01” (Edit)"]').click();
+		cy.get('a.row-title').contains("Print Title 01").first().click();
 		cy.get("#title").clear();
 		cy.get("#title").type("Print Title 02");
 		cy.get("#pi-section-add").click();
@@ -47,7 +47,7 @@ describe('Publish a new print issue', () => {
 
 	it("Export Issues", () => {
 		cy.visit(`wp-admin/edit.php?post_type=print-issue`);
-		cy.get('[aria-label="“Print Title 02” (Edit)"]').click();
+		cy.get('a.row-title').contains("Print Title 02").first().click();
 		cy.window().document().then(function (doc) {
 			doc.addEventListener('click', () => {
 			  setTimeout(function () { doc.location.reload() }, 5000)
@@ -59,7 +59,7 @@ describe('Publish a new print issue', () => {
 
 	it("Delete issue", () => {
 		cy.visit(`wp-admin/edit.php?post_type=print-issue`);
-		cy.get('[aria-label="“Print Title 02” (Edit)"]').click();
+		cy.get('a.row-title').contains("Print Title 02").first().click();
 		cy.get('.submitdelete').click();
 	});
 });

--- a/tests/cypress/e2e/publications.test.js
+++ b/tests/cypress/e2e/publications.test.js
@@ -16,7 +16,7 @@ describe('Publications', () => {
 
       it("Edit Publications", () => {
         cy.visit(`wp-admin/edit-tags.php?taxonomy=print_issue_publication&post_type=print-issue`);
-        cy.get('[aria-label="“Weekly Articles” (Edit)"]').click();
+		cy.get('a.row-title').contains("Weekly Articles").first().click();
         cy.get('#name').clear();
         cy.get('#name').type('Monthly Articles')
         cy.get('.button').click();
@@ -30,7 +30,7 @@ describe('Publications', () => {
 
       it("Delete Publications", () => {
         cy.visit(`wp-admin/edit-tags.php?taxonomy=print_issue_publication&post_type=print-issue`);
-        cy.get('[aria-label="“Monthly Articles” (Edit)"]').click();
+        cy.get('a.row-title').contains("Monthly Articles").first().click();
         cy.get('.delete').click();
 
         // Verify successful deletion


### PR DESCRIPTION
### Description of the Change

We've had a few failing E2E tests for a while now, particularly when run on `trunk`. This PR fixes all of those and tries to make those less flakey

### How to test the Change

Ensure the E2E workflow runs successfully on this PR

### Changelog Entry

> Developer - Fix failing E2E tests

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
